### PR TITLE
Use github as upstream

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@ WebJar for google-code-prettify
 
 More info: http://webjars.org
 
-Upstream: https://code.google.com/p/google-code-prettify/
+Upstream: https://github.com/google/code-prettify

--- a/pom.xml
+++ b/pom.xml
@@ -7,11 +7,11 @@
         <artifactId>oss-parent</artifactId>
         <version>7</version>
     </parent>
-    
+
     <packaging>jar</packaging>
     <groupId>org.webjars</groupId>
     <artifactId>prettify</artifactId>
-    <version>4-Mar-2014-SNAPSHOT</version>
+    <version>4-Mar-2013-1-SNAPSHOT</version>
     <name>google-code-prettify</name>
     <description>WebJar for google-code-prettify</description>
     <url>http://webjars.org</url>
@@ -36,13 +36,14 @@
         <url>http://github.com/webjars/prettify</url>
         <connection>scm:git:https://github.com/webjars/prettify.git</connection>
         <developerConnection>scm:git:https://github.com/webjars/prettify.git</developerConnection>
-        <tag>HEAD</tag>
+        <tag>prettify-4-Mar-2013</tag>
     </scm>
-    
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <upstream.version>4-Mar-2013</upstream.version>
-        <upstream.url>https://google-code-prettify.googlecode.com/files</upstream.url>
+        <upstream.version.dir>2013-03-04</upstream.version.dir>
+        <upstream.url>https://github.com/google/code-prettify/releases/download/${upstream.version.dir}</upstream.url>
         <destDir>${project.build.outputDirectory}/META-INF/resources/webjars/${project.artifactId}/${upstream.version}</destDir>
     </properties>
 


### PR DESCRIPTION
Changing upstream to github because the files are not hosted on https://google-code-prettify.googlecode.com/files anymore.

Note that I’ve changed the version project to `4-Mar-2013` which is an existing project version. So when creating a new release we would need to delete the current git tag.